### PR TITLE
Exceptions

### DIFF
--- a/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
+++ b/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.time.withTimeoutOrNull
 import loliland.rsocketext.common.RSocketHandler
+import loliland.rsocketext.common.exception.SilentCancellationException
 import loliland.rsocketext.common.extensions.jsonPayload
 import java.time.Duration
 import kotlin.coroutines.coroutineContext
@@ -39,7 +40,7 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
     abstract fun onConnectionClosed(socket: RSocket)
 
     fun shutdown() {
-        socket?.cancel("Gracefully closed.")
+        socket?.cancel(SilentCancellationException("Gracefully closed."))
     }
 
     suspend fun metadataPush(

--- a/common/src/main/kotlin/loliland/rsocketext/common/RSocketHandler.kt
+++ b/common/src/main/kotlin/loliland/rsocketext/common/RSocketHandler.kt
@@ -13,6 +13,7 @@ import io.rsocket.kotlin.payload.Payload
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import loliland.rsocketext.common.dto.ResponseError
+import loliland.rsocketext.common.exception.ResponseException
 import loliland.rsocketext.common.exception.SilentCancellationException
 import loliland.rsocketext.common.extensions.errorPayload
 import loliland.rsocketext.common.extensions.jsonPayload
@@ -111,6 +112,8 @@ abstract class RSocketHandler(val mapper: ObjectMapper) {
                     is ResponseError -> errorPayload(error = response, mapper = mapper)
                     else -> jsonPayload(data = response, mapper = mapper)
                 }
+            } catch (e: ResponseException) {
+                errorPayload(error = e.error, mapper = mapper)
             } catch (e: Throwable) {
                 // Propagate current coroutine cancellation
                 coroutineContext.ensureActive()

--- a/common/src/main/kotlin/loliland/rsocketext/common/exception/ResponseException.kt
+++ b/common/src/main/kotlin/loliland/rsocketext/common/exception/ResponseException.kt
@@ -1,0 +1,5 @@
+package loliland.rsocketext.common.exception
+
+import loliland.rsocketext.common.dto.ResponseError
+
+class ResponseException(val error: ResponseError) : RuntimeException(error.message, null, true, false)

--- a/common/src/main/kotlin/loliland/rsocketext/common/exception/SilentCancellationException.kt
+++ b/common/src/main/kotlin/loliland/rsocketext/common/exception/SilentCancellationException.kt
@@ -1,0 +1,10 @@
+package loliland.rsocketext.common.exception
+
+import kotlinx.coroutines.CancellationException
+
+class SilentCancellationException(message: String?) : CancellationException(message) {
+
+    override fun fillInStackTrace(): Throwable {
+        return this
+    }
+}

--- a/server/src/main/kotlin/loliland/rsocketext/server/RSocketServerHandler.kt
+++ b/server/src/main/kotlin/loliland/rsocketext/server/RSocketServerHandler.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.time.withTimeoutOrNull
 import loliland.rsocketext.common.RSocketHandler
 import loliland.rsocketext.common.SetupData
+import loliland.rsocketext.common.exception.SilentCancellationException
 import loliland.rsocketext.common.extensions.readValue
 import java.lang.reflect.ParameterizedType
 import java.time.Duration
@@ -64,7 +65,7 @@ abstract class RSocketServerHandler<S : SetupData>(mapper: ObjectMapper) : RSock
     }
 
     fun close(connection: RSocketConnection<S>) {
-        connection.socket.cancel("Gracefully closed.")
+        connection.socket.cancel(SilentCancellationException("Gracefully closed."))
     }
 
     inline fun eachConnection(action: (RSocketConnection<S>) -> Unit) = connections.values.forEach(action)


### PR DESCRIPTION
1. Добавил в try-catch вызовы `coroutineContext.ensureActive()`, чтобы, если корутина, вызвавшая, например, `onRequestResponse`, была отменена, `CancellationException` не проглатывался и не подменялся на возврат `errorPayload`, который, скорее всего, уже никто не обработает.
2. Заменил ручные вызовы `close` на `Closeable#use` из ktor - эта функция умеет вызывать `Throwable#addSuppressed`, что позволит избежать молчаливового проглатывания исключений, когда они вылетели и из try-блока, и из метода `close` (у нас такое было ранее в Minio).
3. Добавил `SilentCancellationException`, которое по задумке должно уменьшить флуд в лог при вызове `shutdown`.
4. Добавил `ResponseException`. Это позволит возвращать `ResponseError` из реализаций `RSocketRoute`, не заменяя в их сигнатуре возвращаемое значение на `Any`. Особых накладных расходов от такого подхода быть не должно, так как аргумент `writableStackTrace=false`. Т.е. метод `Throwable#fillInStackTrace` не вызывается.