### PR TITLE
Rewrite timeouts

### DIFF
--- a/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
+++ b/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
@@ -94,19 +94,12 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
     }
 
     private suspend fun waitConnection(timeout: Duration): RSocket? {
-        val socket = getActiveSocket()
-        if (socket != null) {
-            // Fast path
-            return socket
-        }
+        // Fast path
+        getActiveSocket()?.let { return@waitConnection it }
 
         return withTimeoutOrNull(timeout) {
             while (isActive) {
-                val socket = getActiveSocket()
-                if (socket != null) {
-                    return@withTimeoutOrNull socket
-                }
-
+                getActiveSocket()?.let { return@withTimeoutOrNull socket }
                 connectionState.await()
             }
 

--- a/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
+++ b/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
@@ -59,7 +59,7 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
 
     suspend fun metadataPush(
         metadata: ByteReadPacket,
-        timeout: Duration = DEFAULT_TIMEOUT,
+        timeout: Duration? = DEFAULT_TIMEOUT,
         ifConnectionClosed: () -> Unit = {
             throw IllegalStateException("Failed metadataPush: connection is closed.")
         }
@@ -69,7 +69,7 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
 
     suspend fun fireAndForget(
         payload: Payload,
-        timeout: Duration = DEFAULT_TIMEOUT,
+        timeout: Duration? = DEFAULT_TIMEOUT,
         ifConnectionClosed: () -> Unit = {
             throw IllegalStateException("Failed fireAndForget: connection is closed.")
         }
@@ -77,27 +77,27 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
         waitConnection(timeout)?.fireAndForget(payload) ?: ifConnectionClosed()
     }
 
-    suspend fun requestResponse(payload: Payload, timeout: Duration = DEFAULT_TIMEOUT): Payload? {
+    suspend fun requestResponse(payload: Payload, timeout: Duration? = DEFAULT_TIMEOUT): Payload? {
         return waitConnection(timeout)?.requestResponse(payload)
     }
 
-    suspend fun requestStream(payload: Payload, timeout: Duration = DEFAULT_TIMEOUT): Flow<Payload>? {
+    suspend fun requestStream(payload: Payload, timeout: Duration? = DEFAULT_TIMEOUT): Flow<Payload>? {
         return waitConnection(timeout)?.requestStream(payload)
     }
 
     suspend fun requestChannel(
         initPayload: Payload,
         payloads: Flow<Payload>,
-        timeout: Duration = DEFAULT_TIMEOUT
+        timeout: Duration? = DEFAULT_TIMEOUT
     ): Flow<Payload>? {
         return waitConnection(timeout)?.requestChannel(initPayload, payloads)
     }
 
-    private suspend fun waitConnection(timeout: Duration): RSocket? {
+    private suspend fun waitConnection(timeout: Duration?): RSocket? {
         // Fast path
         getActiveSocket()?.let { return@waitConnection it }
 
-        return withTimeoutOrNull(timeout) {
+        return if (timeout == null) null else withTimeoutOrNull(timeout) {
             while (isActive) {
                 getActiveSocket()?.let { return@withTimeoutOrNull socket }
                 connectionState.await()

--- a/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
+++ b/client/src/main/kotlin/loliland/rsocketext/client/RSocketClientHandler.kt
@@ -5,18 +5,15 @@ import io.ktor.utils.io.core.*
 import io.rsocket.kotlin.ConnectionAcceptorContext
 import io.rsocket.kotlin.RSocket
 import io.rsocket.kotlin.payload.Payload
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.job
-import kotlinx.coroutines.time.withTimeoutOrNull
 import loliland.rsocketext.common.RSocketHandler
 import loliland.rsocketext.common.exception.SilentCancellationException
 import loliland.rsocketext.common.extensions.jsonPayload
-import java.time.Duration
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mapper) {
 
@@ -63,52 +60,56 @@ abstract class RSocketClientHandler(mapper: ObjectMapper) : RSocketHandler(mappe
 
     suspend fun metadataPush(
         metadata: ByteReadPacket,
-        duration: Duration = Duration.ofMinutes(5),
+        timeout: Duration = DEFAULT_TIMEOUT,
         ifConnectionClosed: () -> Unit = {
             throw IllegalStateException("Failed metadataPush: connection is closed.")
         }
     ) {
-        waitConnection(duration)
+        waitConnection(timeout)
         socket?.metadataPush(metadata) ?: ifConnectionClosed()
     }
 
     suspend fun fireAndForget(
         payload: Payload,
-        duration: Duration = Duration.ofMinutes(5),
+        timeout: Duration = DEFAULT_TIMEOUT,
         ifConnectionClosed: () -> Unit = {
             throw IllegalStateException("Failed fireAndForget: connection is closed.")
         }
     ) {
-        waitConnection(duration)
+        waitConnection(timeout)
         socket?.fireAndForget(payload) ?: ifConnectionClosed()
     }
 
-    suspend fun requestResponse(payload: Payload, duration: Duration = Duration.ofMinutes(5)): Payload? {
-        waitConnection(duration)
+    suspend fun requestResponse(payload: Payload, timeout: Duration = DEFAULT_TIMEOUT): Payload? {
+        waitConnection(timeout)
         return socket?.requestResponse(payload)
     }
 
-    suspend fun requestStream(payload: Payload, duration: Duration = Duration.ofMinutes(5)): Flow<Payload>? {
-        waitConnection(duration)
+    suspend fun requestStream(payload: Payload, timeout: Duration = DEFAULT_TIMEOUT): Flow<Payload>? {
+        waitConnection(timeout)
         return socket?.requestStream(payload)
     }
 
     suspend fun requestChannel(
         initPayload: Payload,
         payloads: Flow<Payload>,
-        duration: Duration = Duration.ofMinutes(5)
+        timeout: Duration = DEFAULT_TIMEOUT
     ): Flow<Payload>? {
-        waitConnection(duration)
+        waitConnection(timeout)
         return socket?.requestChannel(initPayload, payloads)
     }
 
-    private suspend fun waitConnection(duration: Duration) {
+    private suspend fun waitConnection(timeout: Duration) {
         while (coroutineContext.isActive && !connected) {
-            val timeout = withTimeoutOrNull(duration) { connectionState.await() }
-            if (timeout == null) {
+            val timeoutResult = withTimeoutOrNull(timeout) { connectionState.await() }
+            if (timeoutResult == null) {
                 break
             }
         }
+    }
+
+    companion object {
+        private val DEFAULT_TIMEOUT = 5.minutes
     }
 }
 


### PR DESCRIPTION
1. Заменил `java.time.Duration` на `kotlin.time.Duration` - с ним проще работать в Kotlin. Правда придётся подправить всё, что зависит от rsocket-ext, но это будут мелкие правки.
2. Теперь таймаут в `waitConnection` считается не с начала каждой итерации цикла (что могло в некоторых условиях приводить к бесконечному циклу), а с момента потери соединения для `RSocketServerHandler` или с начала выполнения метода для `RSocketClientHandler`.
3. Вместо таймаута теперь можно передать null, чтобы предотвратить ожидание восстановления соединения. Это будет полезно для маловажных, но очень частых запросов, которые в некоторых случаях при разрыве соединения с одним или несколькими клиентами могли привести к бесконечному разрастанию очереди `NioEventLoop` в Netty. Теперь же для них можно будет не вызывать `withTimeoutOrNull` и таким образом не порождать лишние `ScheduledFutureTask`